### PR TITLE
Dropping .subrepo file since its no longer a subrepo

### DIFF
--- a/sampi/.subrepo
+++ b/sampi/.subrepo
@@ -1,1 +1,0 @@
-https://github.com/flynn/sampi


### PR DESCRIPTION
.subrepo file needs to be gone

Signed-off-by: Jeff Lindsay progrium@gmail.com (github: progrium)
