### PR TITLE
Support explicit ports

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -72,8 +73,9 @@ type manifestRunner struct {
 }
 
 type manifestService struct {
-	Args []string          `json:"args"`
-	Env  map[string]string `json:"env"`
+	Args     []string          `json:"args"`
+	Env      map[string]string `json:"env"`
+	TCPPorts []string          `json:"tcp_ports"`
 }
 
 func dockerEnv(m map[string]string) []string {
@@ -98,6 +100,16 @@ func (m *manifestRunner) runManifest(r io.Reader) (map[string]*ManifestData, err
 			ExternalIP: m.externalIP,
 			ports:      m.ports,
 		}
+
+		// Add explicit tcp ports to data.TCPPorts
+		for _, port := range service.TCPPorts {
+			port, err := strconv.Atoi(port)
+			if err != nil {
+				return nil, err
+			}
+			data.TCPPorts = append(data.TCPPorts, port)
+		}
+
 		var buf bytes.Buffer
 
 		interp := func(s string) (string, error) {

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
     ]
   },
   "discoverd": {
-    "args": ["-bind=:{{ .TCPPort 0 }}", "-etcd=http://{{ .Services.etcd.InternalIP }}:{{ index .Services.etcd.TCPPorts 0 }}"]
+    "args": ["-bind=:{{ .TCPPort 0 }}", "-etcd=http://{{ .Services.etcd.InternalIP }}:{{ index .Services.etcd.TCPPorts 0 }}"],
+    "tcp_ports": ["1111"]
   }
 }

--- a/types/types.go
+++ b/types/types.go
@@ -20,7 +20,8 @@ type Job struct {
 	// TODO: move to Attrs/Resources?
 	TCPPorts int
 
-	Config *docker.Config
+	Config     *docker.Config
+	HostConfig *docker.HostConfig
 }
 
 type ResourceValue struct {


### PR DESCRIPTION
It seemed odd to me that after spinning up a grid, I wasn't _sure_ of the discoverd address, so this change ensures it is always on port 1111.

This also (I think) allows ports to be explicitly set for scheduled jobs (e.g. if I want to start Redis explicitly on port 6379, I can pass in the `HostConfig` to do that).

This is my first time writing Go, I mainly copied and pasted stuff :wink:

Relates to #5
