### PR TITLE
Send more information to event subscribers

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -42,6 +42,7 @@ type AddJobsRes struct {
 type Event struct {
 	Event string
 	JobID string
+	Job   *ActiveJob
 }
 
 type ActiveJob struct {


### PR DESCRIPTION
The main reason for this is so that the scheduler can make more informative decisions when restarting jobs by knowing when they started and what their exit code was.
