### PR TITLE
Ensure the RPC Host has a backend

### DIFF
--- a/lorne.go
+++ b/lorne.go
@@ -64,7 +64,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	go serveHTTP(&Host{state: state}, &attachHandler{state: state, backend: backend})
+	go serveHTTP(&Host{state: state, backend: backend}, &attachHandler{state: state, backend: backend})
 
 	if *force {
 		if err := backend.Cleanup(); err != nil {


### PR DESCRIPTION
This fixes stopping jobs via RPC, ensuring [h.backend is set](https://github.com/flynn/flynn-host/blob/master/rpc.go#L45).

Fixes https://github.com/flynn/flynn-controller/issues/26
