### PR TITLE
Initialise sampi state listeners map

### DIFF
--- a/sampi/state.go
+++ b/sampi/state.go
@@ -24,7 +24,11 @@ type State struct {
 
 func NewState() *State {
 	curr := make(map[string]host.Host)
-	return &State{curr: &curr, streams: make(map[string]chan<- *host.Job)}
+	return &State{
+		curr:      &curr,
+		listeners: make(map[chan host.HostEvent]struct{}),
+		streams:   make(map[string]chan<- *host.Job),
+	}
 }
 
 func (s *State) Begin() {


### PR DESCRIPTION
Spotted by `flynn-test` :smile:

```
panic: runtime error: assignment to entry in nil map

goroutine 109 [running]:
runtime.panic(0x759ba0, 0x98c2f3)
        /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/flynn/flynn-host/sampi.(*State).AddListener(0xc20801bbd0, 0xc20815c4e0)
        /home/ubuntu/go/src/github.com/flynn/flynn-host/sampi/state.go:139 +0x79
github.com/flynn/flynn-host/sampi.(*Cluster).StreamHostEvents(0xc20803a658, 0xc20815c2a0, 0xc20815c300, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/flynn/flynn-host/sampi/rpc.go:101 +0x8f
reflect.Value.call(0x709500, 0x768778, 0x0, 0x130, 0x79fa30, 0x4, 0xc20815c420, 0x3, 0x3, 0x0, ...)
        /usr/local/go/src/pkg/reflect/value.go:563 +0x1210
reflect.Value.Call(0x709500, 0x768778, 0x0, 0x130, 0xc20815c420, 0x3, 0x3, 0x0, 0x0, 0x0)
        /usr/local/go/src/pkg/reflect/value.go:411 +0xd7
github.com/flynn/rpcplus.(*service).call(0xc20801bc20, 0xc20800f3c0, 0xc20813d4e0, 0xc208050aa0, 0xc2080e2f00, 0x69fba0, 0x991
438, 0x0, 0x196, 0x0, ...)
        /tmp/godep/rev/cd/680b2cd620be36cd39a58270c6a2894dd2e810/src/github.com/flynn/rpcplus/server.go:475 +0xb6a
created by github.com/flynn/rpcplus.(*Server).ServeCodecWithContext
        /tmp/godep/rev/cd/680b2cd620be36cd39a58270c6a2894dd2e810/src/github.com/flynn/rpcplus/server.go:612 +0x6bb
```
